### PR TITLE
Support running from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ Main features:
     See [touchstone-auth readme](https://github.com/meson800/touchstone-auth#quickstart) for more details.
 4. Run `./covidpass.py help` to see the list of available commands.
 
-The first time you run it (and once month after that), you'll need to accept the Duo notification on your phone.
+The first time you run it (and once a month after that), you'll need to accept the Duo notification on your phone.
+
+The `credentials.json` file can be located in the same directory as
+`covidpass.py` or in your current working directory.  A `cookies.json` file
+will be created/updated in the same directory, to keep your Duo
+authentication.
 
 ## API
 

--- a/covidpass.py
+++ b/covidpass.py
@@ -144,8 +144,8 @@ def main():
     try:
         credentials = read_credentials()
     except Exception as e:
-        print('Could not open `credentials.json` file.')
-        print('Make sure it is in your currect working directory.')
+        print('Could not open `%s` file.' % credentials_filename)
+        print('Make sure it is in the covidpyss directory or your currect working directory.')
         raise e
 
     try:


### PR DESCRIPTION
This PR lets you run `covidpass.py` from any directory (e.g. home or root directory).

* `credentials.json` can be in the same directory as `covidpass_api.py` or in the current directory.  Former takes priority (in the same way that `.` is usually last in `PATH`).
* If `certfile` is a relative path, it's treated relative to `credentials.json` (instead of the current working directory).
* `cookies.json` is located wherever `credentials.json` is.